### PR TITLE
Remove deletion step for Render Preview service in CI

### DIFF
--- a/.github/workflows/cicd-check.yml
+++ b/.github/workflows/cicd-check.yml
@@ -48,22 +48,6 @@ jobs:
     concurrency: create-preview
 
     steps:
-      - name: Get Render Preview services
-        uses: fjogeleit/http-request-action@v1
-        id: service
-        with:
-          method: GET
-          url: https://api.render.com/v1/services?type=web_service&limit=1&name=ntpu-linebot%20Preview%20preview
-          bearerToken: ${{ secrets.RENDER_API_KEY }}
-
-      - if: steps.service.outputs.response != '[]'
-        name: Delete Render Preview service
-        uses: fjogeleit/http-request-action@v1
-        with:
-          method: DELETE
-          url: https://api.render.com/v1/services/${{ fromJson(steps.service.outputs.response)[0].service.id }}
-          bearerToken: ${{ secrets.RENDER_API_KEY }}
-
       - name: Create Render Preview Service
         uses: fjogeleit/http-request-action@v1
         id: render
@@ -99,6 +83,7 @@ jobs:
   cleanup:
     name: DELETE PREVIEW SERVICE
     runs-on: ubuntu-latest
+    needs: cd
 
     steps:
       - name: Get Render Preview services


### PR DESCRIPTION
Eliminate the step that deletes the Render Preview service from the CI workflow. This streamlines the process by focusing on service creation only.