### PR TITLE
Update preview workflow to generate underlined head_ref style

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -4,10 +4,27 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: preview-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
+  prepare:
+    name: PREPARE HEAD REF
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate github.head_ref with underline style
+        id: head_ref
+        run: echo "head_ref=$(echo ${{ github.head_ref }} | tr / _)" >> "$GITHUB_OUTPUT"
+
+    outputs:
+      head_ref: ${{ steps.head_ref.outputs.head_ref }}
+
   delete:
     name: Delete Preview Image
     runs-on: ubuntu-latest
+    needs: prepare
 
     permissions:
       packages: write
@@ -19,12 +36,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           container: ${{ github.event.repository.name }}
-          prune-tags-regexes: ^${{ github.head_ref }}$
+          prune-tags-regexes: ^${{ needs.prepare.outputs.head_ref }}$
 
       - name: Add comment to Pull Request
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-            ## Preview is deleted!
+            ## Preview Has Been Deleted!
 
-            The Preview Image have been deleted.
+            The Preview Image has been deleted.

--- a/.github/workflows/upsert-preview.yml
+++ b/.github/workflows/upsert-preview.yml
@@ -9,9 +9,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  preview:
+  prepare:
+    name: PREPARE HEAD REF
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate github.head_ref with underline style
+        id: head_ref
+        run: echo "head_ref=$(echo ${{ github.head_ref }} | tr / _)" >> "$GITHUB_OUTPUT"
+
+    outputs:
+      head_ref: ${{ steps.head_ref.outputs.head_ref }}
+
+  upsert:
     name: Push Preview Image to Registry
     runs-on: ubuntu-latest
+    needs: prepare
 
     permissions:
       packages: write
@@ -35,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.head_ref }}
+          tags: ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.head_ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -43,9 +56,9 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-            ## Preview is created or updated!
+            ## Preview Has Been Created or Updated!
 
-            The Preview Image URL is ghcr.io/${{ github.repository }}:${{ github.head_ref }}.
+            The Preview Image URL is ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.head_ref }}.
 
       - name: Docker Scout
         uses: docker/scout-action@v1


### PR DESCRIPTION
Revise the preview workflow to include a prepare job that generates the head_ref in an underlined format, ensuring consistent tagging and messaging in the workflow.