### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upsert-preview.yml
+++ b/.github/workflows/upsert-preview.yml
@@ -16,6 +16,8 @@ jobs:
   prepare:
     name: Prepare Image Tag Name
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Generate github.head_ref with underline style


### PR DESCRIPTION
Potential fix for [https://github.com/garyellow/ntpu-linebot/security/code-scanning/2](https://github.com/garyellow/ntpu-linebot/security/code-scanning/2)

To fix the issue, add a `permissions` block to the `prepare` job in the workflow file. The permissions should be set to the least privilege required for the job to function correctly. Since the `prepare` job only reads the `github.head_ref` variable and generates an output, it does not require write permissions. The `contents: read` permission is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
